### PR TITLE
Migrate counters from Supabase Postgres to Upstash Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Upstash Redis (counters + rate limiting). From the Upstash console -> database details.
+UPSTASH_REDIS_REST_URL="https://your-db.upstash.io"
+UPSTASH_REDIS_REST_TOKEN="..."
+
+# Supabase / Postgres — only required while migrating from the old Prisma backend
+# via scripts/migrate-to-redis.ts. Safe to remove once migration has been verified
+# and Prisma has been deleted from the project.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:6543/postgres?pgbouncer=true&connection_limit=1"
+DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/postgres"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@types/node": "20.2.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "autoprefixer": "10.4.14",
         "clsx": "^1.2.1",
         "date-fns": "^2.30.0",
@@ -24,18 +26,20 @@
         "postcss": "^8.5.10",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "rehype-autolink-headings": "*",
-        "rehype-katex": "*",
-        "rehype-mathjax": "*",
-        "rehype-slug": "*",
-        "remark-gfm": "*",
-        "remark-math": "*",
-        "swr": "*",
+        "rehype-autolink-headings": "latest",
+        "rehype-katex": "latest",
+        "rehype-mathjax": "latest",
+        "rehype-slug": "latest",
+        "remark-gfm": "latest",
+        "remark-math": "latest",
+        "swr": "latest",
         "tailwindcss": "3.3.2",
         "typescript": "^5.9.2"
       },
       "devDependencies": {
-        "prisma": "^4.15.0"
+        "dotenv": "^17.4.2",
+        "prisma": "^4.15.0",
+        "tsx": "^4.21.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -67,7 +71,6 @@
       "resolved": "https://registry.npmjs.org/@contentlayer2/cli/-/cli-0.5.8.tgz",
       "integrity": "sha512-sPXTe24tXPpru6hE45riBj7xjVIDuTfjQXbwitwcNkm0yd0kNJaDPBA2C4U5mRFgg1a/aftlIKeVavlkBnuZQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@contentlayer2/core": "0.5.8",
         "@contentlayer2/utils": "0.5.8",
@@ -80,7 +83,6 @@
       "resolved": "https://registry.npmjs.org/@contentlayer2/client/-/client-0.5.8.tgz",
       "integrity": "sha512-mc6uGuHI5ygO6s5KHhoFfiUN7BUUHrPUsxjU+EnGHjMo3+rcYnHd+G6cDDcf0fB21cX7NbJ57V9UlAMu5JKM0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@contentlayer2/core": "0.5.8"
       }
@@ -123,7 +125,6 @@
       "resolved": "https://registry.npmjs.org/@contentlayer2/source-files/-/source-files-0.5.8.tgz",
       "integrity": "sha512-yoKjA7D8OeMV7KcRwq2ygnyAMw8x4BLx9du8EkA1nBg0uSAjOpNIBVvNjrSuRLnm1/WdH97BwKCQF0Qf1yz5kQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@contentlayer2/core": "0.5.8",
         "@contentlayer2/utils": "0.5.8",
@@ -142,7 +143,6 @@
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@contentlayer2/source-remote-files/-/source-remote-files-0.5.8.tgz",
       "integrity": "sha512-sjk7QIB5NHeIM6J4/U7z7/ZUN+JENkN142tUHyQUagltlwYQ4Y9KMaa4RHmwYAfEwfTgQ6w0snPpQfINZY+MPw==",
-      "peer": true,
       "dependencies": {
         "@contentlayer2/core": "0.5.8",
         "@contentlayer2/source-files": "0.5.8",
@@ -191,6 +191,7 @@
       "resolved": "https://registry.npmjs.org/@effect-ts/core/-/core-0.60.5.tgz",
       "integrity": "sha512-qi1WrtJA90XLMnj2hnUszW9Sx4dXP03ZJtCc5DiUBIOhF4Vw7plfb65/bdBySPoC9s7zy995TdUX1XBSxUkl5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@effect-ts/system": "^0.57.5"
       }
@@ -276,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -292,9 +293,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -308,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -324,9 +325,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -340,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -356,9 +357,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -372,9 +373,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -388,9 +389,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -404,9 +405,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -420,9 +421,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -436,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -452,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -468,9 +469,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -484,9 +485,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -500,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -516,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -532,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -548,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -564,9 +565,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -580,9 +581,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -596,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -612,9 +613,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -628,9 +629,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -644,9 +645,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -660,9 +661,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -676,9 +677,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1776,6 +1777,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1809,6 +1811,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -1997,6 +2000,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -2023,6 +2027,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
       "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/context-async-hooks": "1.30.1",
         "@opentelemetry/core": "1.30.1",
@@ -2296,6 +2301,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2627,6 +2633,40 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
@@ -2641,6 +2681,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3054,6 +3095,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -3269,7 +3311,6 @@
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.1.tgz",
       "integrity": "sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "website"
       ],
@@ -3656,6 +3697,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3902,11 +3956,12 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3914,32 +3969,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -3969,6 +4024,7 @@
       "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -4128,6 +4184,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.55.0.tgz",
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4363,6 +4420,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5592,7 +5650,6 @@
       "resolved": "https://registry.npmjs.org/imagescript/-/imagescript-1.3.1.tgz",
       "integrity": "sha512-ue/zxSyEzj7je8Nlt2vjY9GEa2BbScFSRZJq7OTVDZFp0r57fyuxrlsF8qWgxTP+kP8WklTw4by/ZEYVX5S13w==",
       "license": "(AGPL-3.0-or-later OR MIT)",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -8248,6 +8305,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8353,6 +8411,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "4.16.2"
       },
@@ -8443,6 +8502,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8452,6 +8512,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9864,6 +9925,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9953,14 +10015,34 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typanion": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
       "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "website"
       ]
@@ -10068,6 +10150,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10093,6 +10176,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -10599,7 +10688,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@types/node": "20.2.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "autoprefixer": "10.4.14",
     "clsx": "^1.2.1",
     "date-fns": "^2.30.0",
@@ -37,7 +39,9 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
-    "prisma": "^4.15.0"
+    "dotenv": "^17.4.2",
+    "prisma": "^4.15.0",
+    "tsx": "^4.21.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/scripts/migrate-to-redis.ts
+++ b/scripts/migrate-to-redis.ts
@@ -1,0 +1,72 @@
+// One-shot: copy view/download counts from Supabase (Prisma) to Upstash Redis.
+// Run with: npx tsx scripts/migrate-to-redis.ts
+// Requires DATABASE_URL, DIRECT_URL, UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN in .env.local.
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { PrismaClient } from "@prisma/client";
+import { Redis } from "@upstash/redis";
+
+const prisma = new PrismaClient();
+const redis = Redis.fromEnv();
+
+const TYPE_INT_TO_STRING: Record<number, "problems" | "answer-key"> = {
+  1: "problems",
+  2: "answer-key",
+};
+
+async function main() {
+  console.log("Reading from Supabase...");
+  const [views, downloads] = await Promise.all([
+    prisma.views.findMany(),
+    prisma.downloads.findMany(),
+  ]);
+  console.log(`  views rows: ${views.length}`);
+  console.log(`  downloads rows: ${downloads.length}`);
+
+  const viewsTotal = views.reduce((sum, r) => sum + r.count, 0);
+  const downloadsTotal = downloads.reduce((sum, r) => sum + r.count, 0);
+  console.log(`  views total: ${viewsTotal}`);
+  console.log(`  downloads total: ${downloadsTotal}`);
+
+  console.log("Writing to Upstash...");
+  const pipeline = redis.multi();
+  for (const row of views) {
+    pipeline.set(`views:${row.articleslug}`, row.count);
+  }
+  for (const row of downloads) {
+    const typeStr = TYPE_INT_TO_STRING[row.type];
+    if (!typeStr) {
+      console.warn(`  skipping unknown type=${row.type} for ${row.articleslug}`);
+      continue;
+    }
+    pipeline.set(`downloads:${row.articleslug}:${typeStr}`, row.count);
+  }
+  pipeline.set("views:total", viewsTotal);
+  pipeline.set("downloads:total", downloadsTotal);
+  await pipeline.exec();
+
+  console.log("Verifying...");
+  const [verifyViewsTotal, verifyDownloadsTotal] = await Promise.all([
+    redis.get<number>("views:total"),
+    redis.get<number>("downloads:total"),
+  ]);
+  console.log(`  Upstash views:total = ${verifyViewsTotal}`);
+  console.log(`  Upstash downloads:total = ${verifyDownloadsTotal}`);
+
+  if (verifyViewsTotal !== viewsTotal || verifyDownloadsTotal !== downloadsTotal) {
+    throw new Error("Totals mismatch — investigate before deploying.");
+  }
+
+  console.log("Done.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/api/downloads/route.ts
+++ b/src/app/api/downloads/route.ts
@@ -1,19 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { redis } from "@/lib/redis";
 import { ratelimit, getClientIp } from "@/lib/ratelimit";
-
-const MAX_SLUG_LENGTH = 191;
-const SLUG_PATTERN = /^[a-zA-Z0-9_\-/.]+$/;
-const DOWNLOAD_TYPES = ["problems", "answer-key"] as const;
-type DownloadType = (typeof DOWNLOAD_TYPES)[number];
-
-function isValidSlug(slug: string | null): slug is string {
-  return !!slug && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug);
-}
-
-function isValidType(type: string | null): type is DownloadType {
-  return type !== null && (DOWNLOAD_TYPES as readonly string[]).includes(type);
-}
+import { isValidSlug } from "@/lib/slug";
+import { isValidDownloadType } from "@/lib/download-types";
 
 export async function GET(req: NextRequest) {
   try {
@@ -29,7 +18,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
     }
 
-    if (!isValidType(type)) {
+    if (!isValidDownloadType(type)) {
       return NextResponse.json(
         { message: "Invalid or missing type" },
         { status: 400 }
@@ -56,7 +45,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
     }
 
-    if (!isValidType(type)) {
+    if (!isValidDownloadType(type)) {
       return NextResponse.json(
         { message: "Invalid or missing type" },
         { status: 400 }

--- a/src/app/api/downloads/route.ts
+++ b/src/app/api/downloads/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
     const slug = req.nextUrl.searchParams.get("slug");
     const type = req.nextUrl.searchParams.get("type");
 
-    if (slug === null) {
+    if (!slug) {
       const total = (await redis.get<number>("downloads:total")) ?? 0;
       return NextResponse.json({ downloads: total }, { status: 200 });
     }

--- a/src/app/api/downloads/route.ts
+++ b/src/app/api/downloads/route.ts
@@ -1,42 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { redis } from "@/lib/redis";
+import { ratelimit, getClientIp } from "@/lib/ratelimit";
 
-export const revalidate = 60;
+const MAX_SLUG_LENGTH = 191;
+const SLUG_PATTERN = /^[a-zA-Z0-9_\-/.]+$/;
+const DOWNLOAD_TYPES = ["problems", "answer-key"] as const;
+type DownloadType = (typeof DOWNLOAD_TYPES)[number];
 
-const mapType = (t: "problems" | "answer-key") => (t === "problems" ? 1 : 2);
+function isValidSlug(slug: string | null): slug is string {
+  return !!slug && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug);
+}
+
+function isValidType(type: string | null): type is DownloadType {
+  return type !== null && (DOWNLOAD_TYPES as readonly string[]).includes(type);
+}
 
 export async function GET(req: NextRequest) {
   try {
     const slug = req.nextUrl.searchParams.get("slug");
-    const type = req.nextUrl.searchParams.get("type") as
-      | "problems"
-      | "answer-key"
-      | null;
+    const type = req.nextUrl.searchParams.get("type");
 
-    if (!slug) {
-      const total = await prisma.downloads.aggregate({ _sum: { count: true } });
-      return NextResponse.json(
-        { downloads: total._sum.count ?? 0 },
-        { status: 200 }
-      );
+    if (slug === null) {
+      const total = (await redis.get<number>("downloads:total")) ?? 0;
+      return NextResponse.json({ downloads: total }, { status: 200 });
     }
 
-    if (!type) {
+    if (!isValidSlug(slug)) {
+      return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
+    }
+
+    if (!isValidType(type)) {
       return NextResponse.json(
-        { message: "Download type is required" },
+        { message: "Invalid or missing type" },
         { status: 400 }
       );
     }
 
-    const row = await prisma.downloads.findUnique({
-      where: { downloadsId: { articleslug: slug, type: mapType(type) } },
-      select: { count: true },
-    });
-
-    return NextResponse.json(
-      { downloads: row?.count ?? 0, type },
-      { status: 200 }
-    );
+    const count = (await redis.get<number>(`downloads:${slug}:${type}`)) ?? 0;
+    return NextResponse.json({ downloads: count, type }, { status: 200 });
   } catch (e) {
     console.error("GET /downloads", e);
     return NextResponse.json(
@@ -49,37 +50,39 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const slug = req.nextUrl.searchParams.get("slug");
-    const type = req.nextUrl.searchParams.get("type") as
-      | "problems"
-      | "answer-key"
-      | null;
+    const type = req.nextUrl.searchParams.get("type");
 
-    if (!slug)
+    if (!isValidSlug(slug)) {
+      return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
+    }
+
+    if (!isValidType(type)) {
       return NextResponse.json(
-        { message: "Article slug is required" },
+        { message: "Invalid or missing type" },
         { status: 400 }
       );
-    if (!type)
-      return NextResponse.json(
-        { message: "Download type is required" },
-        { status: 400 }
-      );
+    }
 
-    const updated = await prisma.downloads.upsert({
-      where: { downloadsId: { articleslug: slug, type: mapType(type) } },
-      create: { articleslug: slug, type: mapType(type), count: 1 },
-      update: { count: { increment: 1 } },
-    });
-
-    const { revalidateTag } = await import("next/cache");
-    revalidateTag("downloads");
-    revalidateTag(`downloads:${slug}`);
-    revalidateTag(`downloads:${slug}:${type}`);
-
-    return NextResponse.json(
-      { downloads: updated.count, type },
-      { status: 200 }
+    const { success, reset } = await ratelimit.limit(
+      `downloads:${getClientIp(req)}`
     );
+    if (!success) {
+      return NextResponse.json(
+        { message: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(Math.ceil((reset - Date.now()) / 1000)) },
+        }
+      );
+    }
+
+    const [count] = await redis
+      .multi()
+      .incr(`downloads:${slug}:${type}`)
+      .incr("downloads:total")
+      .exec<[number, number]>();
+
+    return NextResponse.json({ downloads: count, type }, { status: 200 });
   } catch (e) {
     console.error("POST /downloads", e);
     return NextResponse.json(

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   try {
     const slug = req.nextUrl.searchParams.get("slug");
 
-    if (slug === null) {
+    if (!slug) {
       const total = (await redis.get<number>("views:total")) ?? 0;
       return NextResponse.json({ views: total }, { status: 200 });
     }

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -1,13 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { redis } from "@/lib/redis";
 import { ratelimit, getClientIp } from "@/lib/ratelimit";
-
-const MAX_SLUG_LENGTH = 191;
-const SLUG_PATTERN = /^[a-zA-Z0-9_\-/.]+$/;
-
-function isValidSlug(slug: string | null): slug is string {
-  return !!slug && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug);
-}
+import { isValidSlug } from "@/lib/slug";
 
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -1,25 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { redis } from "@/lib/redis";
+import { ratelimit, getClientIp } from "@/lib/ratelimit";
 
-export const revalidate = 60;
+const MAX_SLUG_LENGTH = 191;
+const SLUG_PATTERN = /^[a-zA-Z0-9_\-/.]+$/;
+
+function isValidSlug(slug: string | null): slug is string {
+  return !!slug && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug);
+}
 
 export async function GET(req: NextRequest) {
   try {
     const slug = req.nextUrl.searchParams.get("slug");
-    if (!slug) {
-      const total = await prisma.views.aggregate({ _sum: { count: true } });
-      return NextResponse.json(
-        { views: total._sum.count ?? 0 },
-        { status: 200 }
-      );
+
+    if (slug === null) {
+      const total = (await redis.get<number>("views:total")) ?? 0;
+      return NextResponse.json({ views: total }, { status: 200 });
     }
 
-    const row = await prisma.views.findUnique({
-      where: { articleslug: slug },
-      select: { count: true },
-    });
+    if (!isValidSlug(slug)) {
+      return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
+    }
 
-    return NextResponse.json({ views: row?.count ?? 0 }, { status: 200 });
+    const count = (await redis.get<number>(`views:${slug}`)) ?? 0;
+    return NextResponse.json({ views: count }, { status: 200 });
   } catch (e) {
     console.error("GET /views", e);
     return NextResponse.json(
@@ -32,25 +36,29 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const slug = req.nextUrl.searchParams.get("slug");
-    if (!slug) {
+
+    if (!isValidSlug(slug)) {
+      return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
+    }
+
+    const { success, reset } = await ratelimit.limit(`views:${getClientIp(req)}`);
+    if (!success) {
       return NextResponse.json(
-        { message: "Article slug is required" },
-        { status: 400 }
+        { message: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(Math.ceil((reset - Date.now()) / 1000)) },
+        }
       );
     }
 
-    const updated = await prisma.views.upsert({
-      where: { articleslug: slug },
-      create: { articleslug: slug, count: 1 },
-      update: { count: { increment: 1 } },
-    });
+    const [count] = await redis
+      .multi()
+      .incr(`views:${slug}`)
+      .incr("views:total")
+      .exec<[number, number]>();
 
-    // Bust the cached GET
-    const { revalidateTag } = await import("next/cache");
-    revalidateTag("views"); // total endpoint if you add tags later
-    revalidateTag(`views:${slug}`); // per-slug endpoint
-
-    return NextResponse.json({ views: updated.count }, { status: 200 });
+    return NextResponse.json({ views: count }, { status: 200 });
   } catch (e) {
     console.error("POST /views", e);
     return NextResponse.json(

--- a/src/components/ArticleData.tsx
+++ b/src/components/ArticleData.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useDownloads, useViews } from "@/lib/queries";
+import type { DownloadType } from "@/lib/download-types";
 
 function ViewsCounter({ slug }: { slug: string }) {
   const { data, isLoading } = useViews(slug);
@@ -12,7 +13,7 @@ function DownloadsCounter({
   type,
 }: {
   slug: string;
-  type: "problems" | "answer-key" | "any";
+  type: DownloadType | "any";
 }) {
   const { data: problems, isLoading: problemsIsLoading } = useDownloads(
     slug,
@@ -47,7 +48,7 @@ export default function ArticleData({
 }: {
   slug: string;
   type: "views" | "downloads";
-  downloadsType?: "problems" | "answer-key" | "any";
+  downloadsType?: DownloadType | "any";
 }) {
   if (type === "views") return <ViewsCounter slug={slug} />;
   if (downloadsType === "any")

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useRegisterDownload } from "@/lib/queries";
+import type { DownloadType } from "@/lib/download-types";
 
 interface DownloadButtonProps {
-  type: "problems" | "answer-key";
+  type: DownloadType;
   slug: string;
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { DownloadType } from "./download-types";
+
 export async function getViews(slug?: string) {
   const url = slug
     ? `/api/views?slug=${encodeURIComponent(slug)}`
@@ -21,7 +23,7 @@ export async function postView(slug: string) {
 
 export async function getDownloads(
   slug?: string,
-  type?: "problems" | "answer-key"
+  type?: DownloadType
 ) {
   const qs = new URLSearchParams();
   if (slug !== undefined) qs.set("slug", slug);
@@ -34,10 +36,7 @@ export async function getDownloads(
   return res.json() as Promise<{ downloads: number; type?: string | null }>;
 }
 
-export async function postDownload(
-  slug: string,
-  type: "problems" | "answer-key"
-) {
+export async function postDownload(slug: string, type: DownloadType) {
   const qs = new URLSearchParams({ slug, type });
   const res = await fetch(`/api/downloads?${qs.toString()}`, {
     method: "POST",

--- a/src/lib/download-types.ts
+++ b/src/lib/download-types.ts
@@ -1,0 +1,6 @@
+export const DOWNLOAD_TYPES = ["problems", "answer-key"] as const;
+export type DownloadType = (typeof DOWNLOAD_TYPES)[number];
+
+export function isValidDownloadType(type: string | null): type is DownloadType {
+  return type !== null && (DOWNLOAD_TYPES as readonly string[]).includes(type);
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getViews, postView, getDownloads, postDownload } from "./api";
+import type { DownloadType } from "./download-types";
 
 export function useViews(slug?: string) {
   return useQuery({
@@ -38,17 +39,14 @@ export function useIncrementView(slug: string) {
   });
 }
 
-export function useDownloads(slug: string, type: "problems" | "answer-key") {
+export function useDownloads(slug: string, type: DownloadType) {
   return useQuery({
     queryKey: ["downloads", slug, type],
     queryFn: () => getDownloads(slug, type),
   });
 }
 
-export function useRegisterDownload(
-  slug: string,
-  type: "problems" | "answer-key"
-) {
+export function useRegisterDownload(slug: string, type: DownloadType) {
   const qc = useQueryClient();
   const key = ["downloads", slug, type];
   return useMutation({

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,0 +1,21 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { redis } from "./redis";
+
+const g = global as unknown as { ratelimit?: Ratelimit };
+
+export const ratelimit =
+  g.ratelimit ??
+  new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(10, "1 m"),
+    prefix: "ratelimit",
+    analytics: false,
+  });
+
+if (process.env.NODE_ENV !== "production") g.ratelimit = ratelimit;
+
+export function getClientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? "unknown";
+}

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,0 +1,7 @@
+import { Redis } from "@upstash/redis";
+
+const g = global as unknown as { redis?: Redis };
+
+export const redis = g.redis ?? Redis.fromEnv();
+
+if (process.env.NODE_ENV !== "production") g.redis = redis;

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,6 @@
+export const MAX_SLUG_LENGTH = 191;
+export const SLUG_PATTERN = /^[a-zA-Z0-9_\-/.]+$/;
+
+export function isValidSlug(slug: string | null): slug is string {
+  return !!slug && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug);
+}


### PR DESCRIPTION
Replaces Prisma + Postgres with Upstash Redis for view and download counters. Atomic INCR removes the race condition on concurrent writes, drops the connection-pool concerns on serverless, and lets us delete the Int-as-enum hack and the dead unstable_cache/revalidateTag plumbing.

Adds rate limiting (sliding window, 10 req/min per IP) on POST handlers since Upstash makes it trivial. Validates slug and download type at the route boundary instead of trusting query params.

API contract is unchanged — clients (api.ts, queries.ts, components) all continue to work.

Includes a one-shot migration script (scripts/migrate-to-redis.ts) that copies existing counts from Supabase to Redis and seeds the totals. Already run locally; counts verified.

Prisma deps + schema kept for now so the migration script still runs during cutover. Will be removed in a follow-up after prod soak.